### PR TITLE
Homepage Quick Start: Style commands as monospace code

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -59,7 +59,7 @@ pygmentsOptions = "linenos=table"
         install_step_one_title = "Check"
         install_step_one_description = "Java <span>8 or later</span> is required"
         install_step_one_command = "java -version"
-        install_step_one_subtitle = "Version numbers 1.8.y_z and 8 identify the same Java release."
+        install_step_one_subtitle = "Version numbers <code class=\"text-muted\">1.8.y_z</code> and <code class=\"text-muted\">8</code> identify the same Java release."
 
         install_step_two_title = "Install"
         install_step_two_description = "<span>One line</span> installation"
@@ -83,7 +83,7 @@ pygmentsOptions = "linenos=table"
         work_count = 2
         show_view_all_work_button = true
 
-    [params.work] 
+    [params.work]
         # Work Page
         order_work_grid = 'weight' # shuffle, lastmod, weight
         show_filters = true # show filters

--- a/themes/hugo-advance/layouts/partials/install.html
+++ b/themes/hugo-advance/layouts/partials/install.html
@@ -33,9 +33,9 @@
                 </div>
                 <div class="head_bg"></div>
                 <div class="head">
-                  <highlight>{{ .Site.Params.homepage.install_step_one_command }}</highlight>
+                  <code class="text-muted">{{ .Site.Params.homepage.install_step_one_command }}</code>
                 </div> </br></br>
-                <p>{{ .Site.Params.homepage.install_step_one_subtitle }}</p>
+                <p>{{ .Site.Params.homepage.install_step_one_subtitle | safeHTML }}</p>
               </div>
             </div>
             <div class="col-md-4">
@@ -60,8 +60,8 @@
                 </div>
                 <div class="head_bg"></div>
                 <div class="head">
-                  <highlight>{{ .Site.Params.homepage.install_step_two_command }}</highlight>
-                </div> 
+                  <code class="text-muted">{{ .Site.Params.homepage.install_step_two_command }}</code>
+                </div>
                 <br><br>
                 <p>{{ .Site.Params.homepage.install_step_two_subtitle }}</p>
               </div>
@@ -88,7 +88,7 @@
                 </div>
                 <div class="head_bg"></div>
                 <div class="head">
-                  <highlight>{{ .Site.Params.homepage.install_step_three_command }}</highlight>
+                  <code class="text-muted">{{ .Site.Params.homepage.install_step_three_command }}</code>
                 </div> </br></br>
                 <p>{{ .Site.Params.homepage.install_step_three_subtitle }}</p>
                 </br>


### PR DESCRIPTION
Use monospace in the quick start blocks:
![image](https://user-images.githubusercontent.com/465550/73943082-6dd13700-48f0-11ea-80cb-d6e074f44bca.png)

Would also be good to have the slanted background colour below the numbers, will add that on if I get to it.