### PR TITLE
Make docs nav dropdown link to latest docs if clicked

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,7 +83,7 @@ pygmentsOptions = "linenos=table"
         work_count = 2
         show_view_all_work_button = true
 
-    [params.work] 
+    [params.work]
         # Work Page
         order_work_grid = 'weight' # shuffle, lastmod, weight
         show_filters = true # show filters
@@ -105,6 +105,7 @@ pygmentsOptions = "linenos=table"
 [[menu.main]]
     identifier = "Docs"
 	name = "Docs"
+    url = "/docs/latest/"
     weight = 3
 
 [[menu.main]]


### PR DESCRIPTION
Currently, if you hover over the docs dropdown and click, it just takes you to the top of the current page.

With this change, it takes you to the latest docs instead, which is probably the intention for most users.

Specifically clicking in the red circle here:

<img width="1180" alt="docs_link" src="https://user-images.githubusercontent.com/465550/73957442-aa0f9200-4906-11ea-9b34-419acbddb1cc.png">
