### PR TITLE
Make homepage header nav semitransparent

### DIFF
--- a/themes/hugo-advance/assets/scss/components/_header.scss
+++ b/themes/hugo-advance/assets/scss/components/_header.scss
@@ -179,7 +179,7 @@
   width: 100%;
   top: 0;
   z-index: 10;
-  background: #000;
+  background: rgba(0,0,0,0.3);
   box-shadow: 0 1px 6px 0 rgba(36, 50, 66, 0.15);
   .hamburger {
     color: white;


### PR DESCRIPTION
Personally I think that the header nav looks cooler on the homepage when it's semitransparent:

![image](https://user-images.githubusercontent.com/465550/73957980-7b45eb80-4907-11ea-9854-4ed9ec0ae95a.png)

Instead of how it is currently with a fully black background:

![image](https://user-images.githubusercontent.com/465550/73958032-91ec4280-4907-11ea-8260-66f28dae77ac.png)

Subtle, but 30% more awesome 🤓 😆 