### PR TITLE
Learn: Make tags more label-like

### DIFF
--- a/themes/hugo-advance/assets/scss/pages/work/_work-summary.scss
+++ b/themes/hugo-advance/assets/scss/pages/work/_work-summary.scss
@@ -30,6 +30,9 @@
       font-weight: bold;
       text-transform: uppercase;
       font-size: 0.9rem;
+      background-color: rgba(0,0,0,0.05);
+      padding: 0.1rem 0.3rem;
+      border-radius: 0.2rem;
     }
   }
   .work-content {

--- a/themes/hugo-advance/layouts/work/summary.html
+++ b/themes/hugo-advance/layouts/work/summary.html
@@ -9,7 +9,7 @@
   </div>
   {{ if .Params.works }}
   <div class="work-meta">
-    <p>{{ delimit .Params.works ""}}</p>
+    <span>{{ delimit .Params.works ""}}</span>
   </div>
   {{ end }}
   <div class="work-content">{{ .Params.desciption | plainify | truncate 120 "..." }}</div>


### PR DESCRIPTION
Made it more obvious that the labels under the "learn" cards are in fact labels:

![image](https://user-images.githubusercontent.com/465550/74050455-608e7800-49d6-11ea-8d73-6b75377ec276.png)

(light grey background)