### PR TITLE
Delete word 'Nextflow' from site footer

### DIFF
--- a/themes/hugo-advance/layouts/partials/footer.html
+++ b/themes/hugo-advance/layouts/partials/footer.html
@@ -1,9 +1,1 @@
-<div class="footer">
-  <div class="container">
-    <div class="row">
-      <div class="col-12">
-        <h3 class="footer-title">{{.Site.Title}}</h3>
-      </div>
-    </div>
-  </div>
-</div>
+<div class="footer"></div>


### PR DESCRIPTION
I found the lone static text saying "Nextflow" in the site footer a little distracting. It didn't really add anything, so I deleted it.

Before:

![image](https://user-images.githubusercontent.com/465550/74258571-d6f0ea00-4cf6-11ea-9504-7e6893774d19.png)

After:

![image](https://user-images.githubusercontent.com/465550/74258546-cc365500-4cf6-11ea-9c0e-e0f5d7a143ee.png)
